### PR TITLE
make Travis CI only notify irc if build failed or was fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ script:
 
 notifications:
   irc: "chat.freenode.net#xqf"
+  on_success: change
+  on_failure: always


### PR DESCRIPTION
Continually notifying that everything went as expected seems unnecessary.
